### PR TITLE
Fix: Simplecov reports arrumando a porcentagem

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -3,7 +3,11 @@ require 'spec_helper'
 ENV['RAILS_ENV'] ||= 'test'
 
 require 'simplecov'
-SimpleCov.start 'rails'
+SimpleCov.start 'rails' do
+  add_filter 'app/channels/'
+  add_filter 'app/jobs/'
+  add_filter 'app/mailers/'
+end
 
 require File.expand_path('../../config/environment', __FILE__)
 # Prevent database truncation if the environment is production


### PR DESCRIPTION
## Motivação

Quando utilizamos o simplecov ele leva em consideração todos os códigos da nossa aplicação, alguns arquivos não estamos usando como: ActionCable e ApplicationMailer.

Removi esses arquivos do report mas o ideal seria eles serem apagados.

## Comentários

Agora o relatório está correto :100:  de cobertura :smile: 